### PR TITLE
Add missing build dependency not declared

### DIFF
--- a/rpm/sailmich.spec
+++ b/rpm/sailmich.spec
@@ -11,6 +11,8 @@ BuildRequires:  pkgconfig(sailfishapp) >= 1.0.2
 BuildRequires:  pkgconfig(Qt5Core)
 BuildRequires:  pkgconfig(Qt5Qml)
 BuildRequires:  pkgconfig(Qt5Quick)
+BuildRequires:  pkgconfig(Qt5Concurrent)
+BuildRequires:  pkgconfig(sailfishsecrets)
 BuildRequires:  desktop-file-utils
 
 %description


### PR DESCRIPTION
Fixes builds in clean build environments such as on the OBS.